### PR TITLE
Added LogUniform random sampling tag 't'

### DIFF
--- a/vspace/vspace.py
+++ b/vspace/vspace.py
@@ -373,6 +373,32 @@ def main():
                         % (name, flist[fnum - 1])
                     )
 
+            # user wants to randomly sample a log-uniform distribution
+            elif values[2][0] == "t":
+                if mode == 1:
+                    # check if in random mode, all ok
+                    # construct array of randoms amples
+                    if np.float(values[0]) < 0:
+                        #user has set a negative value for endpoints
+                        #signs on left and right ends must agree! (might want to change for some parameters)
+                        array = -np.power(10, np.random.uniform(
+                            low=np.log10(-np.float(values[0])),
+                            high=np.log10(-np.float(values[1])),
+                            size=np.int(randsize),
+                        ))
+                    else:
+                        array = np.power(10, np.random.uniform(
+                            low=np.log10(np.float(values[0])),
+                            high=np.log10(np.float(values[1])),
+                            size=np.int(randsize),
+                        ))
+                else:
+                    #user tried to use random sampling in grid mode
+                    raise IOError(
+                        "Attempt to draw from a random distribution in grid mode for '%s' for '%s'"
+                        % (name, flist[fnum-1])
+                    )
+
             # user wants to randomly sample a uniform distribution of the SINE of an angle
             elif values[2][0] == "s":
                 if mode == 1:


### PR DESCRIPTION
I added the ability to randomly sample a log-uniform distribution, that way you can equally sample a parameter across a range of orders of magnitude (e.g., sampling from 1e7 to 1e9 randomly will no longer have samples concentrated towards 1e9). The tag for this is t, so for example, to sample dViscRef from 1e7 to 1e9 log-uniform, you can say:
dViscRef [1e7, 1e9, t] visc

The change was made to look like the uniform random and log grid spacing/sampling code.